### PR TITLE
King + Pawn + legalMoveStates

### DIFF
--- a/bishop.cc
+++ b/bishop.cc
@@ -13,10 +13,8 @@ bool Bishop::isLegal(Box &targetBox) {
     return false;
 }
 
-void Bishop::updateLegalMoves() {
-    std::vector<Box> legalMoves;
-    std::vector<int> moveStates;
-
+std::map<Box, int> Bishop::updateLegalMoves() {
+    std::map<Box, int> legalMoves;
 
     int x = this->getX();
     int y = this->getY();
@@ -30,14 +28,13 @@ void Bishop::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x - i][y + i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
+
         // location is empty
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
     for (int i = 1; x + i  < 8 && y - i >= 0; ++i) {
@@ -45,13 +42,12 @@ void Bishop::updateLegalMoves() {
         Box move1(x + i, y - i);
         if (((*(this->getBoard()))[x + i][y - i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+
+        legalMoves[move1] = 0;
     }
 
     for (int i = 1; x - i  >= 0 && y - i >= 0; ++i) {
@@ -59,13 +55,12 @@ void Bishop::updateLegalMoves() {
         Box move1(x - i, y - i);
         if (((*(this->getBoard()))[x - i][y - i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        
+        legalMoves[move1] = 0;
     }
 
     for (int i = 1; x + i  < 8 && y + i < 8; ++i) {
@@ -73,15 +68,13 @@ void Bishop::updateLegalMoves() {
         Box move1(x + i, y + i);
         if (((*(this->getBoard()))[x + i][y + i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        
+        legalMoves[move1] = 0;
     }
 
-    this->getLegalMoves() = &legalMoves;
-    this->getMoveStates() = &moveStates;
+    return legalMoves;
 }

--- a/bishop.cc
+++ b/bishop.cc
@@ -5,7 +5,7 @@ Bishop::Bishop(std::string name, std::vector<std::vector<Piece *>> *board, bool 
 
 bool Bishop::isLegal(Box &targetBox) {
 
-    // if location is EMPTY OR WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
+    // if WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
     if (((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
          (!checkWhitePlayer() && (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) )) {
         return true;
@@ -15,6 +15,8 @@ bool Bishop::isLegal(Box &targetBox) {
 
 void Bishop::updateLegalMoves() {
     std::vector<Box> legalMoves;
+    std::vector<int> moveStates;
+
 
     int x = this->getX();
     int y = this->getY();
@@ -23,15 +25,19 @@ void Bishop::updateLegalMoves() {
     // this is also why we need separate loops for each direction
 
     for (int i = 1; x - i >= 0 && y + i < 8; ++i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
+
         Box move1(x - i, y + i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x - i][y + i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
+        // location is empty
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = 1; x + i  < 8 && y - i >= 0; ++i) {
@@ -40,10 +46,12 @@ void Bishop::updateLegalMoves() {
         if (((*(this->getBoard()))[x + i][y - i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = 1; x - i  >= 0 && y - i >= 0; ++i) {
@@ -52,10 +60,12 @@ void Bishop::updateLegalMoves() {
         if (((*(this->getBoard()))[x - i][y - i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = 1; x + i  < 8 && y + i < 8; ++i) {
@@ -64,11 +74,14 @@ void Bishop::updateLegalMoves() {
         if (((*(this->getBoard()))[x + i][y + i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     this->getLegalMoves() = &legalMoves;
+    this->getMoveStates() = &moveStates;
 }

--- a/bishop.h
+++ b/bishop.h
@@ -9,7 +9,7 @@ class Bishop: public Piece {
 
     public:
         Bishop(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
-        void updateLegalMoves() override;
+        std::map<Box, int> updateLegalMoves() override;
 
 };
 

--- a/king.cc
+++ b/king.cc
@@ -25,7 +25,6 @@ void King::updateLegalMoves() {
     int x = this->getX();
     int y = this->getY();
 
-
     // castling
     // checks if king is white, on it's first move, rook is at it's necessary position,and on it's first move
     if (checkWhitePlayer() && isFirstMove && 
@@ -63,10 +62,15 @@ void King::updateLegalMoves() {
                     
                         // check final position is check
                         if (!checkGame1.isWhiteKingChecked()) {
+                            // put board back into original state
+                            (*(this->getBoard()))[x][y - 2] = nullptr;
+                            (*(this->getBoard()))[x][y] = this;
+
                             // add castling move to King
                             Box castlingKingMove(x, y - 2);
                             legalMoves.push_back(castlingKingMove);
                             moveStates.push_back(2);
+
                             // add castling move to Rook
                             Box castlingRookMove(x, y + 1);
                             (*((*(this->getBoard()))[7][0])->getLegalMoves()).push_back(castlingRookMove);
@@ -114,10 +118,15 @@ void King::updateLegalMoves() {
                     
                         // check final position is check
                         if (!checkGame2.isWhiteKingChecked()) {
+                            // put board back into original state
+                            (*(this->getBoard()))[x][y + 2] = nullptr;
+                            (*(this->getBoard()))[x][y] = this;
+
                             // add castling move to King
                             Box castlingKingMove(x, y + 2);
                             legalMoves.push_back(castlingKingMove);
                             moveStates.push_back(2);
+
                             // add castling move to Rook
                             Box castlingRookMove(x, y + 1);
                             (*((*(this->getBoard()))[7][7])->getLegalMoves()).push_back(castlingRookMove);
@@ -165,10 +174,15 @@ void King::updateLegalMoves() {
                     
                         // check final position is check
                         if (!checkGame3.isBlackKingChecked()) {
+                            // put board back into original state
+                            (*(this->getBoard()))[x][y - 2] = nullptr;
+                            (*(this->getBoard()))[x][y] = this;
+
                             // add castling move to King
                             Box castlingKingMove(x, y - 2);
                             legalMoves.push_back(castlingKingMove);
                             moveStates.push_back(2);
+
                             // add castling move to Rook
                             Box castlingRookMove(x, y - 1);
                             (*((*(this->getBoard()))[0][0])->getLegalMoves()).push_back(castlingRookMove);
@@ -216,10 +230,15 @@ void King::updateLegalMoves() {
                     
                         // check final position is check
                         if (!checkGame4.isBlackKingChecked()) {
+                            // put board back into original state
+                            (*(this->getBoard()))[x][y + 2] = nullptr;
+                            (*(this->getBoard()))[x][y] = this;
+
                             // add castling move to King
                             Box castlingKingMove(x, y + 2);
                             legalMoves.push_back(castlingKingMove);
                             moveStates.push_back(2);
+
                             // add castling move to Rook
                             Box castlingRookMove(x, y + 1);
                             (*((*(this->getBoard()))[0][7])->getLegalMoves()).push_back(castlingRookMove);

--- a/king.cc
+++ b/king.cc
@@ -47,21 +47,21 @@ void King::updateLegalMoves() {
                 checkGame1.checkingForKingCheck();
 
                 // check current position is check
-                if (!checkGame1.isWhiteKingChecked()) {
+                if (!(checkGame1.isWhiteKingChecked())) {
                     King tempKing1("K", this->getBoard(), checkWhitePlayer(), x, y - 1);
                     (*(this->getBoard()))[x][y - 1] = &tempKing1;
                     (*(this->getBoard()))[x][y] = nullptr;
                     checkGame1.checkingForKingCheck();
 
                     // check between position is check
-                    if (!checkGame1.isWhiteKingChecked()) {
+                    if (!(checkGame1.isWhiteKingChecked())) {
                         King tempKing2("K", this->getBoard(), checkWhitePlayer(), x, y - 2);
                         (*(this->getBoard()))[x][y - 2] = &tempKing2;
                         (*(this->getBoard()))[x][y - 1] = nullptr;
                         checkGame1.checkingForKingCheck();
                     
                         // check final position is check
-                        if (!checkGame1.isWhiteKingChecked()) {
+                        if (!(checkGame1.isWhiteKingChecked())) {
                             // put board back into original state
                             (*(this->getBoard()))[x][y - 2] = nullptr;
                             (*(this->getBoard()))[x][y] = this;
@@ -72,7 +72,7 @@ void King::updateLegalMoves() {
                             moveStates.push_back(2);
 
                             // add castling move to Rook
-                            Box castlingRookMove(x, y + 1);
+                            Box castlingRookMove(x, y - 1);
                             (*((*(this->getBoard()))[7][0])->getLegalMoves()).push_back(castlingRookMove);
                             (*((*(this->getBoard()))[7][0])->getMoveStates()).push_back(2);
                         }
@@ -103,21 +103,21 @@ void King::updateLegalMoves() {
                 checkGame2.checkingForKingCheck();
 
                 // check current position is check
-                if (!checkGame2.isWhiteKingChecked()) {
+                if (!(checkGame2.isWhiteKingChecked())) {
                     King tempKing3("K", this->getBoard(), checkWhitePlayer(), x, y + 1);
                     (*(this->getBoard()))[x][y + 1] = &tempKing3;
                     (*(this->getBoard()))[x][y] = nullptr;
                     checkGame2.checkingForKingCheck();
 
                     // check between position is check
-                    if (!checkGame2.isWhiteKingChecked()) {
+                    if (!(checkGame2.isWhiteKingChecked())) {
                         King tempKing4("K", this->getBoard(), checkWhitePlayer(), x, y + 2);
                         (*(this->getBoard()))[x][y + 2] = &tempKing4;
                         (*(this->getBoard()))[x][y + 1] = nullptr;
                         checkGame2.checkingForKingCheck();
                     
                         // check final position is check
-                        if (!checkGame2.isWhiteKingChecked()) {
+                        if (!(checkGame2.isWhiteKingChecked())) {
                             // put board back into original state
                             (*(this->getBoard()))[x][y + 2] = nullptr;
                             (*(this->getBoard()))[x][y] = this;
@@ -159,21 +159,21 @@ void King::updateLegalMoves() {
                 checkGame3.checkingForKingCheck();
 
                 // check current position is check
-                if (!checkGame3.isBlackKingChecked()) {
+                if (!(checkGame3.isBlackKingChecked())) {
                     King tempKing5("k", this->getBoard(), checkWhitePlayer(), x, y - 1);
                     (*(this->getBoard()))[x][y - 1] = &tempKing5;
                     (*(this->getBoard()))[x][y] = nullptr;
                     checkGame3.checkingForKingCheck();
 
                     // check between position is check
-                    if (!checkGame3.isBlackKingChecked()) {
+                    if (!(checkGame3.isBlackKingChecked())) {
                         King tempKing6("k", this->getBoard(), checkWhitePlayer(), x, y - 2);
                         (*(this->getBoard()))[x][y - 2] = &tempKing6;
                         (*(this->getBoard()))[x][y - 1] = nullptr;
                         checkGame3.checkingForKingCheck();
                     
                         // check final position is check
-                        if (!checkGame3.isBlackKingChecked()) {
+                        if (!(checkGame3.isBlackKingChecked())) {
                             // put board back into original state
                             (*(this->getBoard()))[x][y - 2] = nullptr;
                             (*(this->getBoard()))[x][y] = this;
@@ -215,21 +215,21 @@ void King::updateLegalMoves() {
                 checkGame4.checkingForKingCheck();
 
                 // check current position is check
-                if (!checkGame4.isBlackKingChecked()) {
+                if (!(checkGame4.isBlackKingChecked())) {
                     King tempKing7("k", this->getBoard(), checkWhitePlayer(), x, y + 1);
                     (*(this->getBoard()))[x][y + 1] = &tempKing7;
                     (*(this->getBoard()))[x][y] = nullptr;
                     checkGame4.checkingForKingCheck();
 
                     // check between position is check
-                    if (!checkGame4.isBlackKingChecked()) {
+                    if (!(checkGame4.isBlackKingChecked())) {
                         King tempKing8("k", this->getBoard(), checkWhitePlayer(), x, y + 2);
                         (*(this->getBoard()))[x][y + 2] = &tempKing8;
                         (*(this->getBoard()))[x][y + 1] = nullptr;
                         checkGame4.checkingForKingCheck();
                     
                         // check final position is check
-                        if (!checkGame4.isBlackKingChecked()) {
+                        if (!(checkGame4.isBlackKingChecked())) {
                             // put board back into original state
                             (*(this->getBoard()))[x][y + 2] = nullptr;
                             (*(this->getBoard()))[x][y] = this;
@@ -251,107 +251,98 @@ void King::updateLegalMoves() {
 
     // regular moves in 8 directions
 
+
+    
+
+
     if (x - 1 >= 0) {
         Box move1(x - 1, y);
-        if (isLegal(move1) || !((*(this->getBoard()))[move1.getX()][move1.getY()])) {
+        if (isLegal(move1)) {
             legalMoves.push_back(move1);
-
-            if (isLegal(move1)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move1.getX()][move1.getY()])) {
+            legalMoves.push_back(move1);
+            moveStates.push_back(0);
         }
     }
 
     if (x + 1 < 8) {
         Box move2(x + 1, y);
-        if (isLegal(move2) || !((*(this->getBoard()))[move2.getX()][move2.getY()])) {
+        if (isLegal(move2)) {
             legalMoves.push_back(move2);
-
-            if (isLegal(move2)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move2.getX()][move2.getY()])) {
+            legalMoves.push_back(move2);
+            moveStates.push_back(0);
         }
     }
 
     if (y - 1 >= 0) {
         Box move3(x, y - 1);
-        if (isLegal(move3) || !((*(this->getBoard()))[move3.getX()][move3.getY()])) {
+        if (isLegal(move3)) {
             legalMoves.push_back(move3);
-
-            if (isLegal(move3)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move3.getX()][move3.getY()])) {
+            legalMoves.push_back(move3);
+            moveStates.push_back(0);
         }
     }
 
     if (y + 1 < 8) {
         Box move4(x, y + 1);
-        if (isLegal(move4) || !((*(this->getBoard()))[move4.getX()][move4.getY()])) {
+        if (isLegal(move4)) {
             legalMoves.push_back(move4);
-
-            if (isLegal(move4)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+            
+        } else if (!((*(this->getBoard()))[move4.getX()][move4.getY()])) {
+            legalMoves.push_back(move4);
+            moveStates.push_back(0);
         }
     }
 
     if ((x - 1 >= 0) && (y - 1 >= 0)) {
         Box move5(x - 1, y - 1);
-        if (isLegal(move5) || !((*(this->getBoard()))[move5.getX()][move5.getY()])) {
+        if (isLegal(move5)) {
             legalMoves.push_back(move5);
+            moveStates.push_back(1);
 
-            if (isLegal(move5)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+        } else if (!((*(this->getBoard()))[move5.getX()][move5.getY()])) {
+            legalMoves.push_back(move5);
+            moveStates.push_back(0);
         }
     }
 
     if ((x + 1 < 8) && (y - 1 >= 0)) {
         Box move6(x + 1, y - 1);
-        if (isLegal(move6) || !((*(this->getBoard()))[move6.getX()][move6.getY()])) {
+        if (isLegal(move6)) {
             legalMoves.push_back(move6);
-
-            if (isLegal(move6)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move6.getX()][move6.getY()])) {
+            legalMoves.push_back(move6);
+            moveStates.push_back(0);
         }
     }
 
     if ((x - 1 >= 0) && (y + 1 < 8)) {
         Box move7(x - 1, y + 1);
-        if (isLegal(move7) || !((*(this->getBoard()))[move7.getX()][move7.getY()])) {
+        if (isLegal(move7)) {
             legalMoves.push_back(move7);
-
-            if (isLegal(move7)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+            
+        } else if (!((*(this->getBoard()))[move7.getX()][move7.getY()])) {
+            legalMoves.push_back(move7);
+            moveStates.push_back(0);
         }
     }
 
     if ((x + 1 < 8) && (y + 1 < 8)) {
         Box move8(x + 1, y + 1);
-        if (isLegal(move8) || !((*(this->getBoard()))[move8.getX()][move8.getY()])) {
+        if (isLegal(move8)) {
             legalMoves.push_back(move8);
-
-            if (isLegal(move8)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move8.getX()][move8.getY()])) {
+            legalMoves.push_back(move8);
+            moveStates.push_back(0);
         }
     }
 

--- a/king.cc
+++ b/king.cc
@@ -1,0 +1,341 @@
+#include "king.h"
+#include <algorithm>
+
+King::King(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord):
+    Piece{name, board, whitePlayer, xCoord, yCoord}, isFirstMove{true} {}
+
+bool King::getIsFirstMove() {
+    return isFirstMove;
+}
+
+bool King::isLegal(Box &targetBox) {
+    // checks if targetBox is occupied and Piece is of opposite colour (in order to capture)
+    if ((((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) && 
+        ((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
+         (!checkWhitePlayer() && (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ) )) {
+        return true;
+    }
+    return false;
+}
+
+void King::updateLegalMoves() {
+    std::vector<Box> legalMoves;
+    std::vector<int> moveStates;
+
+    int x = this->getX();
+    int y = this->getY();
+
+
+    // castling
+    // checks if king is white, on it's first move, rook is at it's necessary position,and on it's first move
+    if (checkWhitePlayer() && isFirstMove && 
+        ((*(this->getBoard()))[7][0])->getName() == "R" && ((*(this->getBoard()))[7][0])->getIsFirstMove()) {
+            bool isPiece = false;
+            // checks if there are Pieces between the King and Rook used
+            for (int i = 1; y - i > 0 && !isPiece; ++i) {
+                if ((*(this->getBoard()))[x][y - i]) {
+                    isPiece = true;
+                    break;
+                }
+            }
+            
+            if (!isPiece) {
+                // checks if king is in check in current position, final position, and position in between 
+                // (x, y), (x, y - 1), (x, y - 2)
+
+                // current position
+                ChessGame checkGame1(this->getBoard());
+                checkGame1.checkingForKingCheck();
+
+                // check current position is check
+                if (!checkGame1.isWhiteKingChecked()) {
+                    King tempKing1("K", this->getBoard(), checkWhitePlayer(), x, y - 1);
+                    (*(this->getBoard()))[x][y - 1] = &tempKing1;
+                    (*(this->getBoard()))[x][y] = nullptr;
+                    checkGame1.checkingForKingCheck();
+
+                    // check between position is check
+                    if (!checkGame1.isWhiteKingChecked()) {
+                        King tempKing2("K", this->getBoard(), checkWhitePlayer(), x, y - 2);
+                        (*(this->getBoard()))[x][y - 2] = &tempKing2;
+                        (*(this->getBoard()))[x][y - 1] = nullptr;
+                        checkGame1.checkingForKingCheck();
+                    
+                        // check final position is check
+                        if (!checkGame1.isWhiteKingChecked()) {
+                            // add castling move to King
+                            Box castlingKingMove(x, y - 2);
+                            legalMoves.push_back(castlingKingMove);
+                            moveStates.push_back(2);
+                            // add castling move to Rook
+                            Box castlingRookMove(x, y + 1);
+                            (*((*(this->getBoard()))[7][0])->getLegalMoves()).push_back(castlingRookMove);
+                            (*((*(this->getBoard()))[7][0])->getMoveStates()).push_back(2);
+                        }
+                    }
+                }
+            }
+    }
+
+    // castling
+    // checks if king is white, on it's first move, rook is at it's necessary position,and on it's first move
+    if (checkWhitePlayer() && isFirstMove && 
+        ((*(this->getBoard()))[7][7])->getName() == "R" && ((*(this->getBoard()))[7][7])->getIsFirstMove()) {
+            bool isPiece = false;
+            // checks if there are Pieces between the King and Rook used
+            for (int i = 1; y + i < 8 && !isPiece; ++i) {
+                if ((*(this->getBoard()))[x][y + i]) {
+                    isPiece = true;
+                    break;
+                }
+            }
+            
+            if (!isPiece) {
+                // checks if king is in check in current position, final position, and position in between 
+                // (x, y), (x, y + 1), (x, y + 2)
+
+                // current position
+                ChessGame checkGame2(this->getBoard());
+                checkGame2.checkingForKingCheck();
+
+                // check current position is check
+                if (!checkGame2.isWhiteKingChecked()) {
+                    King tempKing3("K", this->getBoard(), checkWhitePlayer(), x, y + 1);
+                    (*(this->getBoard()))[x][y + 1] = &tempKing3;
+                    (*(this->getBoard()))[x][y] = nullptr;
+                    checkGame2.checkingForKingCheck();
+
+                    // check between position is check
+                    if (!checkGame2.isWhiteKingChecked()) {
+                        King tempKing4("K", this->getBoard(), checkWhitePlayer(), x, y + 2);
+                        (*(this->getBoard()))[x][y + 2] = &tempKing4;
+                        (*(this->getBoard()))[x][y + 1] = nullptr;
+                        checkGame2.checkingForKingCheck();
+                    
+                        // check final position is check
+                        if (!checkGame2.isWhiteKingChecked()) {
+                            // add castling move to King
+                            Box castlingKingMove(x, y + 2);
+                            legalMoves.push_back(castlingKingMove);
+                            moveStates.push_back(2);
+                            // add castling move to Rook
+                            Box castlingRookMove(x, y + 1);
+                            (*((*(this->getBoard()))[7][7])->getLegalMoves()).push_back(castlingRookMove);
+                            (*((*(this->getBoard()))[7][7])->getMoveStates()).push_back(2);
+                        }
+                    }
+                }
+            }
+    }
+
+    // castling black player
+    // checks if king is black, on it's first move, rook is at it's necessary position,and on it's first move
+    if (!checkWhitePlayer() && isFirstMove && 
+        ((*(this->getBoard()))[0][0])->getName() == "r" && ((*(this->getBoard()))[0][0])->getIsFirstMove()) {
+            bool isPiece = false;
+            // checks if there are Pieces between the King and Rook used
+            for (int i = 1; y - i >= 0 && !isPiece; ++i) {
+                if ((*(this->getBoard()))[x][y - i]) {
+                    isPiece = true;
+                    break;
+                }
+            }
+            
+            if (!isPiece) {
+                // checks if king is in check in current position, final position, and position in between 
+                // (x, y), (x, y + 1), (x, y + 2)
+
+                // current position
+                ChessGame checkGame3(this->getBoard());
+                checkGame3.checkingForKingCheck();
+
+                // check current position is check
+                if (!checkGame3.isBlackKingChecked()) {
+                    King tempKing5("k", this->getBoard(), checkWhitePlayer(), x, y - 1);
+                    (*(this->getBoard()))[x][y - 1] = &tempKing5;
+                    (*(this->getBoard()))[x][y] = nullptr;
+                    checkGame3.checkingForKingCheck();
+
+                    // check between position is check
+                    if (!checkGame3.isBlackKingChecked()) {
+                        King tempKing6("k", this->getBoard(), checkWhitePlayer(), x, y - 2);
+                        (*(this->getBoard()))[x][y - 2] = &tempKing6;
+                        (*(this->getBoard()))[x][y - 1] = nullptr;
+                        checkGame3.checkingForKingCheck();
+                    
+                        // check final position is check
+                        if (!checkGame3.isBlackKingChecked()) {
+                            // add castling move to King
+                            Box castlingKingMove(x, y - 2);
+                            legalMoves.push_back(castlingKingMove);
+                            moveStates.push_back(2);
+                            // add castling move to Rook
+                            Box castlingRookMove(x, y - 1);
+                            (*((*(this->getBoard()))[0][0])->getLegalMoves()).push_back(castlingRookMove);
+                            (*((*(this->getBoard()))[0][0])->getMoveStates()).push_back(2);
+                        }
+                    }
+                }
+            }
+    }
+
+    // castling black player
+    // checks if king is black, on it's first move, rook is at it's necessary position,and on it's first move
+    if (!checkWhitePlayer() && isFirstMove && 
+        ((*(this->getBoard()))[0][7])->getName() == "r" && ((*(this->getBoard()))[0][7])->getIsFirstMove()) {
+            bool isPiece = false;
+            // checks if there are Pieces between the King and Rook used
+            for (int i = 1; y + i < 8 && !isPiece; ++i) {
+                if ((*(this->getBoard()))[x][y + i]) {
+                    isPiece = true;
+                    break;
+                }
+            }
+            
+            if (!isPiece) {
+                // checks if king is in check in current position, final position, and position in between 
+                // (x, y), (x, y + 1), (x, y + 2)
+
+                // current position
+                ChessGame checkGame4(this->getBoard());
+                checkGame4.checkingForKingCheck();
+
+                // check current position is check
+                if (!checkGame4.isBlackKingChecked()) {
+                    King tempKing7("k", this->getBoard(), checkWhitePlayer(), x, y + 1);
+                    (*(this->getBoard()))[x][y + 1] = &tempKing7;
+                    (*(this->getBoard()))[x][y] = nullptr;
+                    checkGame4.checkingForKingCheck();
+
+                    // check between position is check
+                    if (!checkGame4.isBlackKingChecked()) {
+                        King tempKing8("k", this->getBoard(), checkWhitePlayer(), x, y + 2);
+                        (*(this->getBoard()))[x][y + 2] = &tempKing8;
+                        (*(this->getBoard()))[x][y + 1] = nullptr;
+                        checkGame4.checkingForKingCheck();
+                    
+                        // check final position is check
+                        if (!checkGame4.isBlackKingChecked()) {
+                            // add castling move to King
+                            Box castlingKingMove(x, y + 2);
+                            legalMoves.push_back(castlingKingMove);
+                            moveStates.push_back(2);
+                            // add castling move to Rook
+                            Box castlingRookMove(x, y + 1);
+                            (*((*(this->getBoard()))[0][7])->getLegalMoves()).push_back(castlingRookMove);
+                            (*((*(this->getBoard()))[0][7])->getMoveStates()).push_back(2);
+                        }
+                    }
+                }
+            }
+    }
+
+    // regular moves in 8 directions
+
+    if (x - 1 >= 0) {
+        Box move1(x - 1, y);
+        if (isLegal(move1) || !((*(this->getBoard()))[move1.getX()][move1.getY()])) {
+            legalMoves.push_back(move1);
+
+            if (isLegal(move1)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if (x + 1 < 8) {
+        Box move2(x + 1, y);
+        if (isLegal(move2) || !((*(this->getBoard()))[move2.getX()][move2.getY()])) {
+            legalMoves.push_back(move2);
+
+            if (isLegal(move2)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if (y - 1 >= 0) {
+        Box move3(x, y - 1);
+        if (isLegal(move3) || !((*(this->getBoard()))[move3.getX()][move3.getY()])) {
+            legalMoves.push_back(move3);
+
+            if (isLegal(move3)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if (y + 1 < 8) {
+        Box move4(x, y + 1);
+        if (isLegal(move4) || !((*(this->getBoard()))[move4.getX()][move4.getY()])) {
+            legalMoves.push_back(move4);
+
+            if (isLegal(move4)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if ((x - 1 >= 0) && (y - 1 >= 0)) {
+        Box move5(x - 1, y - 1);
+        if (isLegal(move5) || !((*(this->getBoard()))[move5.getX()][move5.getY()])) {
+            legalMoves.push_back(move5);
+
+            if (isLegal(move5)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if ((x + 1 < 8) && (y - 1 >= 0)) {
+        Box move6(x + 1, y - 1);
+        if (isLegal(move6) || !((*(this->getBoard()))[move6.getX()][move6.getY()])) {
+            legalMoves.push_back(move6);
+
+            if (isLegal(move6)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if ((x - 1 >= 0) && (y + 1 < 8)) {
+        Box move7(x - 1, y + 1);
+        if (isLegal(move7) || !((*(this->getBoard()))[move7.getX()][move7.getY()])) {
+            legalMoves.push_back(move7);
+
+            if (isLegal(move7)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    if ((x + 1 < 8) && (y + 1 < 8)) {
+        Box move8(x + 1, y + 1);
+        if (isLegal(move8) || !((*(this->getBoard()))[move8.getX()][move8.getY()])) {
+            legalMoves.push_back(move8);
+
+            if (isLegal(move8)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
+    }
+
+    this->getLegalMoves() = &legalMoves;
+    this->getMoveStates() = &moveStates;
+}

--- a/king.cc
+++ b/king.cc
@@ -18,9 +18,8 @@ bool King::isLegal(Box &targetBox) {
     return false;
 }
 
-void King::updateLegalMoves() {
-    std::vector<Box> legalMoves;
-    std::vector<int> moveStates;
+std::map<Box, int> King::updateLegalMoves() {
+    std::map<Box, int> legalMoves;
 
     int x = this->getX();
     int y = this->getY();
@@ -68,13 +67,11 @@ void King::updateLegalMoves() {
 
                             // add castling move to King
                             Box castlingKingMove(x, y - 2);
-                            legalMoves.push_back(castlingKingMove);
-                            moveStates.push_back(2);
+                            legalMoves[castlingKingMove] = 2;
 
                             // add castling move to Rook
                             Box castlingRookMove(x, y - 1);
-                            (*((*(this->getBoard()))[7][0])->getLegalMoves()).push_back(castlingRookMove);
-                            (*((*(this->getBoard()))[7][0])->getMoveStates()).push_back(2);
+                            (*(((*(this->getBoard()))[7][0])->getLegalMoves()))[castlingRookMove] = 2;
                         }
                     }
                 }
@@ -124,13 +121,11 @@ void King::updateLegalMoves() {
 
                             // add castling move to King
                             Box castlingKingMove(x, y + 2);
-                            legalMoves.push_back(castlingKingMove);
-                            moveStates.push_back(2);
+                            legalMoves[castlingKingMove] = 2;
 
                             // add castling move to Rook
                             Box castlingRookMove(x, y + 1);
-                            (*((*(this->getBoard()))[7][7])->getLegalMoves()).push_back(castlingRookMove);
-                            (*((*(this->getBoard()))[7][7])->getMoveStates()).push_back(2);
+                            (*(((*(this->getBoard()))[7][7])->getLegalMoves()))[castlingRookMove] = 2;
                         }
                     }
                 }
@@ -180,13 +175,11 @@ void King::updateLegalMoves() {
 
                             // add castling move to King
                             Box castlingKingMove(x, y - 2);
-                            legalMoves.push_back(castlingKingMove);
-                            moveStates.push_back(2);
+                            legalMoves[castlingKingMove] = 2;
 
                             // add castling move to Rook
                             Box castlingRookMove(x, y - 1);
-                            (*((*(this->getBoard()))[0][0])->getLegalMoves()).push_back(castlingRookMove);
-                            (*((*(this->getBoard()))[0][0])->getMoveStates()).push_back(2);
+                            (*(((*(this->getBoard()))[0][0])->getLegalMoves()))[castlingRookMove] = 2;
                         }
                     }
                 }
@@ -236,13 +229,11 @@ void King::updateLegalMoves() {
 
                             // add castling move to King
                             Box castlingKingMove(x, y + 2);
-                            legalMoves.push_back(castlingKingMove);
-                            moveStates.push_back(2);
+                            legalMoves[castlingKingMove] = 2;
 
                             // add castling move to Rook
                             Box castlingRookMove(x, y + 1);
-                            (*((*(this->getBoard()))[0][7])->getLegalMoves()).push_back(castlingRookMove);
-                            (*((*(this->getBoard()))[0][7])->getMoveStates()).push_back(2);
+                            (*(((*(this->getBoard()))[0][7])->getLegalMoves()))[castlingRookMove] = 2;
                         }
                     }
                 }
@@ -254,94 +245,74 @@ void King::updateLegalMoves() {
     if (x - 1 >= 0) {
         Box move1(x - 1, y);
         if (isLegal(move1)) {
-            legalMoves.push_back(move1);
-            moveStates.push_back(1);
+            legalMoves[move1] = 1;
         } else if (!((*(this->getBoard()))[move1.getX()][move1.getY()])) {
-            legalMoves.push_back(move1);
-            moveStates.push_back(0);
+            legalMoves[move1] = 0;
         }
     }
 
     if (x + 1 < 8) {
         Box move2(x + 1, y);
         if (isLegal(move2)) {
-            legalMoves.push_back(move2);
-            moveStates.push_back(1);
+            legalMoves[move2] = 1;
         } else if (!((*(this->getBoard()))[move2.getX()][move2.getY()])) {
-            legalMoves.push_back(move2);
-            moveStates.push_back(0);
+            legalMoves[move2] = 0;
         }
     }
 
     if (y - 1 >= 0) {
         Box move3(x, y - 1);
         if (isLegal(move3)) {
-            legalMoves.push_back(move3);
-            moveStates.push_back(1);
+            legalMoves[move3] = 1;
         } else if (!((*(this->getBoard()))[move3.getX()][move3.getY()])) {
-            legalMoves.push_back(move3);
-            moveStates.push_back(0);
+            legalMoves[move3] = 0;
         }
     }
 
     if (y + 1 < 8) {
         Box move4(x, y + 1);
         if (isLegal(move4)) {
-            legalMoves.push_back(move4);
-            moveStates.push_back(1);
-            
+            legalMoves[move4] = 1;
         } else if (!((*(this->getBoard()))[move4.getX()][move4.getY()])) {
-            legalMoves.push_back(move4);
-            moveStates.push_back(0);
+            legalMoves[move4] = 0;
         }
     }
 
     if ((x - 1 >= 0) && (y - 1 >= 0)) {
         Box move5(x - 1, y - 1);
         if (isLegal(move5)) {
-            legalMoves.push_back(move5);
-            moveStates.push_back(1);
-
+            legalMoves[move5] = 1;
         } else if (!((*(this->getBoard()))[move5.getX()][move5.getY()])) {
-            legalMoves.push_back(move5);
-            moveStates.push_back(0);
+            legalMoves[move5] = 0;
         }
     }
 
     if ((x + 1 < 8) && (y - 1 >= 0)) {
         Box move6(x + 1, y - 1);
         if (isLegal(move6)) {
-            legalMoves.push_back(move6);
-            moveStates.push_back(1);
+            legalMoves[move6] = 1;
         } else if (!((*(this->getBoard()))[move6.getX()][move6.getY()])) {
-            legalMoves.push_back(move6);
-            moveStates.push_back(0);
+            legalMoves[move6] = 0;
         }
     }
 
     if ((x - 1 >= 0) && (y + 1 < 8)) {
         Box move7(x - 1, y + 1);
         if (isLegal(move7)) {
-            legalMoves.push_back(move7);
-            moveStates.push_back(1);
-            
+            legalMoves[move7] = 1;
         } else if (!((*(this->getBoard()))[move7.getX()][move7.getY()])) {
-            legalMoves.push_back(move7);
-            moveStates.push_back(0);
+            legalMoves[move7] = 0;
         }
     }
 
     if ((x + 1 < 8) && (y + 1 < 8)) {
         Box move8(x + 1, y + 1);
         if (isLegal(move8)) {
-            legalMoves.push_back(move8);
-            moveStates.push_back(1);
+            legalMoves[move8] = 1;
         } else if (!((*(this->getBoard()))[move8.getX()][move8.getY()])) {
-            legalMoves.push_back(move8);
-            moveStates.push_back(0);
+            legalMoves[move8] = 0;
         }
     }
 
-    this->getLegalMoves() = &legalMoves;
-    this->getMoveStates() = &moveStates;
+    return legalMoves;
 }

--- a/king.cc
+++ b/king.cc
@@ -250,11 +250,7 @@ void King::updateLegalMoves() {
     }
 
     // regular moves in 8 directions
-
-
     
-
-
     if (x - 1 >= 0) {
         Box move1(x - 1, y);
         if (isLegal(move1)) {

--- a/king.h
+++ b/king.h
@@ -2,9 +2,7 @@
 #define _KING_H_
 
 #include "piece.h"
-
 #include "chessGame.h"
-//class ChessGame;
 
 class King: public Piece {
     bool isFirstMove;

--- a/king.h
+++ b/king.h
@@ -1,6 +1,19 @@
 #ifndef _KING_H_
 #define _KING_H_
 
+#include "piece.h"
 
+#include "chessGame.h"
+//class ChessGame;
+
+class King: public Piece {
+    bool isFirstMove;
+    bool isLegal(Box &targetBox) override;
+
+    public:
+        King(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
+        bool getIsFirstMove() override;
+        void updateLegalMoves() override;
+};
 
 #endif

--- a/king.h
+++ b/king.h
@@ -11,7 +11,7 @@ class King: public Piece {
     public:
         King(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
         bool getIsFirstMove() override;
-        void updateLegalMoves() override;
+        std::map<Box, int> updateLegalMoves() override;
 };
 
 #endif

--- a/knight.cc
+++ b/knight.cc
@@ -6,8 +6,7 @@ Knight::Knight(std::string name, std::vector<std::vector<Piece *>> *board, bool 
 bool Knight::isLegal(Box &targetBox) {
 
     // if WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
-    if (!((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) || 
-        (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) && 
+    if ((((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) && 
         ((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
          (!checkWhitePlayer() && (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ) )) {
         return true;

--- a/knight.cc
+++ b/knight.cc
@@ -5,7 +5,7 @@ Knight::Knight(std::string name, std::vector<std::vector<Piece *>> *board, bool 
 
 bool Knight::isLegal(Box &targetBox) {
 
-    // if location is EMPTY OR WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
+    // if WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
     if (!((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) || 
         (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) && 
         ((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
@@ -17,51 +17,108 @@ bool Knight::isLegal(Box &targetBox) {
 
 void Knight::updateLegalMoves() {
     std::vector<Box> legalMoves;
+    std::vector<int> moveStates;
 
     int x = this->getX();
     int y = this->getY();
 
-    // if move is capturable (opposite colour) or if box is unoccupied then add to possible moves
-    Box move1(x+2, y+1);
-    Box move2(x-2, y-1);
-    Box move3(x+2, y-1);
-    Box move4(x-2, y+1);
-    Box move5(x+1, y+2);
-    Box move6(x-1, y-2);
-    Box move7(x+1, y-2);
-    Box move8(x-1, y+2);
+    if ((x + 2 < 8) && (y + 1 < 8)) {
+        Box move1(x + 2, y + 1);
+        if (isLegal(move1) || !((*(this->getBoard()))[move1.getX()][move1.getY()])) {
+            legalMoves.push_back(move1);
 
-    if (isLegal(move1)) {
-        legalMoves.push_back(move1);
+            if (isLegal(move1)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move2)) {
-        legalMoves.push_back(move2);
+    if ((x - 2 >= 0) && ( y - 1 >= 0)) {
+        Box move2(x - 2, y - 1);
+        if (isLegal(move2) || !((*(this->getBoard()))[move2.getX()][move2.getY()])) {
+            legalMoves.push_back(move2);
+            if (isLegal(move2)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move3)) {
-        legalMoves.push_back(move3);
+    if ((x + 2 < 8) && ( y - 1 >= 0)) {
+        Box move3(x + 2, y - 1);
+        if (isLegal(move3) || !((*(this->getBoard()))[move3.getX()][move3.getY()])) {
+            legalMoves.push_back(move3);
+            if (isLegal(move3)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move4)) {
-        legalMoves.push_back(move4);
+    if ((x - 2 >= 0) && (y + 1 < 8)) {
+        Box move4(x - 2, y + 1);
+        if (isLegal(move4) || !((*(this->getBoard()))[move4.getX()][move4.getY()])) {
+            legalMoves.push_back(move4);
+            if (isLegal(move4)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move5)) {
-        legalMoves.push_back(move5);
+    if ((x + 1 < 8) && (y + 2 < 8)) {
+        Box move5(x + 1, y + 2);
+        if (isLegal(move5) || !((*(this->getBoard()))[move5.getX()][move5.getY()])) {
+            legalMoves.push_back(move5);
+            if (isLegal(move5)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move6)) {
-        legalMoves.push_back(move6);
+    if ((x - 1 >= 0) && (y - 2 >= 0)) {
+        Box move6(x - 1, y - 2);
+        if (isLegal(move6) || !((*(this->getBoard()))[move6.getX()][move6.getY()])) {
+            legalMoves.push_back(move6);
+            if (isLegal(move6)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move7)) {
-        legalMoves.push_back(move7);
+    if ((x + 1 < 8) && (y - 2 >= 0)) {
+        Box move7(x + 1, y - 2);
+        if (isLegal(move7) || !((*(this->getBoard()))[move7.getX()][move7.getY()])) {
+            legalMoves.push_back(move7);
+            if (isLegal(move7)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
-    if (isLegal(move8)) {
-        legalMoves.push_back(move8);
+    if ((x - 1 >= 0) && (y + 2 < 8)) {
+        Box move8(x - 1, y + 2);
+        if (isLegal(move8) || !((*(this->getBoard()))[move8.getX()][move8.getY()])) {
+            legalMoves.push_back(move8);
+            if (isLegal(move8)) {
+                moveStates.push_back(1);
+            } else {
+                moveStates.push_back(0);
+            }
+        }
     }
 
     this->getLegalMoves() = &legalMoves;
+    this->getMoveStates() = &moveStates;
 }

--- a/knight.cc
+++ b/knight.cc
@@ -23,98 +23,89 @@ void Knight::updateLegalMoves() {
 
     if ((x + 2 < 8) && (y + 1 < 8)) {
         Box move1(x + 2, y + 1);
-        if (isLegal(move1) || !((*(this->getBoard()))[move1.getX()][move1.getY()])) {
+        if (isLegal(move1)) {
             legalMoves.push_back(move1);
-
-            if (isLegal(move1)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move1.getX()][move1.getY()])) {
+            legalMoves.push_back(move1);
+            moveStates.push_back(0);
         }
     }
 
     if ((x - 2 >= 0) && ( y - 1 >= 0)) {
         Box move2(x - 2, y - 1);
-        if (isLegal(move2) || !((*(this->getBoard()))[move2.getX()][move2.getY()])) {
+        if (isLegal(move2)) {
             legalMoves.push_back(move2);
-            if (isLegal(move2)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if(!((*(this->getBoard()))[move2.getX()][move2.getY()])) {
+            legalMoves.push_back(move2);
+            moveStates.push_back(0);
         }
     }
 
     if ((x + 2 < 8) && ( y - 1 >= 0)) {
         Box move3(x + 2, y - 1);
-        if (isLegal(move3) || !((*(this->getBoard()))[move3.getX()][move3.getY()])) {
+        if (isLegal(move3)) {
             legalMoves.push_back(move3);
-            if (isLegal(move3)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move3.getX()][move3.getY()])) {
+            legalMoves.push_back(move3);
+            moveStates.push_back(0);
         }
     }
 
     if ((x - 2 >= 0) && (y + 1 < 8)) {
         Box move4(x - 2, y + 1);
-        if (isLegal(move4) || !((*(this->getBoard()))[move4.getX()][move4.getY()])) {
+        if (isLegal(move4)) {
             legalMoves.push_back(move4);
-            if (isLegal(move4)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move4.getX()][move4.getY()])) {
+            legalMoves.push_back(move4);
+            moveStates.push_back(0);
         }
     }
 
     if ((x + 1 < 8) && (y + 2 < 8)) {
         Box move5(x + 1, y + 2);
-        if (isLegal(move5) || !((*(this->getBoard()))[move5.getX()][move5.getY()])) {
+        if (isLegal(move5)) {
             legalMoves.push_back(move5);
-            if (isLegal(move5)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move5.getX()][move5.getY()])) {
+            legalMoves.push_back(move5);
+            moveStates.push_back(0);
         }
     }
 
     if ((x - 1 >= 0) && (y - 2 >= 0)) {
         Box move6(x - 1, y - 2);
-        if (isLegal(move6) || !((*(this->getBoard()))[move6.getX()][move6.getY()])) {
+        if (isLegal(move6)) {
             legalMoves.push_back(move6);
-            if (isLegal(move6)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move6.getX()][move6.getY()])) {
+            legalMoves.push_back(move6);
+            moveStates.push_back(0);
         }
     }
 
     if ((x + 1 < 8) && (y - 2 >= 0)) {
         Box move7(x + 1, y - 2);
-        if (isLegal(move7) || !((*(this->getBoard()))[move7.getX()][move7.getY()])) {
+        if (isLegal(move7)) {
             legalMoves.push_back(move7);
-            if (isLegal(move7)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move7.getX()][move7.getY()])) {
+            legalMoves.push_back(move7);
+            moveStates.push_back(0);
         }
     }
 
     if ((x - 1 >= 0) && (y + 2 < 8)) {
         Box move8(x - 1, y + 2);
-        if (isLegal(move8) || !((*(this->getBoard()))[move8.getX()][move8.getY()])) {
+        if (isLegal(move8)) {
             legalMoves.push_back(move8);
-            if (isLegal(move8)) {
-                moveStates.push_back(1);
-            } else {
-                moveStates.push_back(0);
-            }
+            moveStates.push_back(1);
+        } else if (!((*(this->getBoard()))[move8.getX()][move8.getY()])) {
+            legalMoves.push_back(move8);
+            moveStates.push_back(0);
         }
     }
 

--- a/knight.cc
+++ b/knight.cc
@@ -14,9 +14,8 @@ bool Knight::isLegal(Box &targetBox) {
     return false;
 }
 
-void Knight::updateLegalMoves() {
-    std::vector<Box> legalMoves;
-    std::vector<int> moveStates;
+std::map<Box, int> Knight::updateLegalMoves() {
+    std::map<Box, int> legalMoves;
 
     int x = this->getX();
     int y = this->getY();
@@ -24,91 +23,74 @@ void Knight::updateLegalMoves() {
     if ((x + 2 < 8) && (y + 1 < 8)) {
         Box move1(x + 2, y + 1);
         if (isLegal(move1)) {
-            legalMoves.push_back(move1);
-            moveStates.push_back(1);
+            legalMoves[move1] = 1;
         } else if (!((*(this->getBoard()))[move1.getX()][move1.getY()])) {
-            legalMoves.push_back(move1);
-            moveStates.push_back(0);
+            legalMoves[move1] = 0;
         }
     }
 
     if ((x - 2 >= 0) && ( y - 1 >= 0)) {
         Box move2(x - 2, y - 1);
         if (isLegal(move2)) {
-            legalMoves.push_back(move2);
-            moveStates.push_back(1);
+            legalMoves[move2] = 1;
         } else if(!((*(this->getBoard()))[move2.getX()][move2.getY()])) {
-            legalMoves.push_back(move2);
-            moveStates.push_back(0);
+            legalMoves[move2] = 0;
         }
     }
 
     if ((x + 2 < 8) && ( y - 1 >= 0)) {
         Box move3(x + 2, y - 1);
         if (isLegal(move3)) {
-            legalMoves.push_back(move3);
-            moveStates.push_back(1);
+            legalMoves[move3] = 1;
         } else if (!((*(this->getBoard()))[move3.getX()][move3.getY()])) {
-            legalMoves.push_back(move3);
-            moveStates.push_back(0);
+            legalMoves[move3] = 0;
         }
     }
 
     if ((x - 2 >= 0) && (y + 1 < 8)) {
         Box move4(x - 2, y + 1);
         if (isLegal(move4)) {
-            legalMoves.push_back(move4);
-            moveStates.push_back(1);
+            legalMoves[move4] = 1;
         } else if (!((*(this->getBoard()))[move4.getX()][move4.getY()])) {
-            legalMoves.push_back(move4);
-            moveStates.push_back(0);
+            legalMoves[move4] = 0;
         }
     }
 
     if ((x + 1 < 8) && (y + 2 < 8)) {
         Box move5(x + 1, y + 2);
         if (isLegal(move5)) {
-            legalMoves.push_back(move5);
-            moveStates.push_back(1);
+            legalMoves[move5] = 1;
         } else if (!((*(this->getBoard()))[move5.getX()][move5.getY()])) {
-            legalMoves.push_back(move5);
-            moveStates.push_back(0);
+            legalMoves[move5] = 0;
         }
     }
 
     if ((x - 1 >= 0) && (y - 2 >= 0)) {
         Box move6(x - 1, y - 2);
         if (isLegal(move6)) {
-            legalMoves.push_back(move6);
-            moveStates.push_back(1);
+            legalMoves[move6] = 1;
         } else if (!((*(this->getBoard()))[move6.getX()][move6.getY()])) {
-            legalMoves.push_back(move6);
-            moveStates.push_back(0);
+            legalMoves[move6] = 0;
         }
     }
 
     if ((x + 1 < 8) && (y - 2 >= 0)) {
         Box move7(x + 1, y - 2);
         if (isLegal(move7)) {
-            legalMoves.push_back(move7);
-            moveStates.push_back(1);
+            legalMoves[move7] = 1;
         } else if (!((*(this->getBoard()))[move7.getX()][move7.getY()])) {
-            legalMoves.push_back(move7);
-            moveStates.push_back(0);
+            legalMoves[move7] = 0;
         }
     }
 
     if ((x - 1 >= 0) && (y + 2 < 8)) {
         Box move8(x - 1, y + 2);
         if (isLegal(move8)) {
-            legalMoves.push_back(move8);
-            moveStates.push_back(1);
+            legalMoves[move8] = 1;
         } else if (!((*(this->getBoard()))[move8.getX()][move8.getY()])) {
-            legalMoves.push_back(move8);
-            moveStates.push_back(0);
+            legalMoves[move8] = 0;
         }
     }
 
-    this->getLegalMoves() = &legalMoves;
-    this->getMoveStates() = &moveStates;
+    return legalMoves;
 }

--- a/knight.h
+++ b/knight.h
@@ -9,7 +9,7 @@ class Knight: public Piece {
     
     public:
         Knight(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
-        void updateLegalMoves() override;
+        std::map<Box, int> updateLegalMoves() override;
 };
 
 #endif

--- a/pawn.cc
+++ b/pawn.cc
@@ -1,0 +1,112 @@
+#include "pawn.h"
+
+Pawn::Pawn(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord):
+    Piece{name, board,whitePlayer, xCoord, yCoord} {}
+
+bool Pawn::isLegal(Box &targetBox) {
+    // checks if targetBox is occupied and Piece is of opposite colour (in order to capture)
+    if ((((*(this->getBoard()))[targetBox.getX()][targetBox.getY()]) && 
+        ((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
+         (!checkWhitePlayer() && (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ) )) {
+        return true;
+    }
+    return false;
+}
+
+void Pawn::updateLegalMoves() {
+    std::vector<Box> legalMoves;
+    std::vector<int> moveStates;
+
+    int x = this->getX();
+    int y = this->getY();
+
+    // Caputre
+    if (checkWhitePlayer() && (x - 1 >= 0) && (y - 1 >= 0)) {
+        Box captureMove1(x - 1, y - 1);
+        if (isLegal(captureMove1)) {
+            legalMoves.push_back(captureMove1);
+            moveStates.push_back(1);
+        }
+    }
+    
+    if (checkWhitePlayer() && (x - 1 >= 0) && (y + 1 < 8)) {
+        Box captureMove2(x - 1, y + 1);
+        if (isLegal(captureMove2)) {
+            legalMoves.push_back(captureMove2);
+            moveStates.push_back(1);
+        }
+    }
+
+    if (!checkWhitePlayer() && (x + 1 < 8) && (y - 1 >= 0)) {
+        Box captureMove3(x + 1, y - 1);
+        if (isLegal(captureMove3)) {
+            legalMoves.push_back(captureMove3);
+            moveStates.push_back(1);
+        }
+    }
+
+    if (!checkWhitePlayer() && (x + 1 < 8) && (y + 1 < 8)) {
+        Box captureMove4(x + 1, y + 1);
+        if (isLegal(captureMove4)) {
+            legalMoves.push_back(captureMove4);
+            moveStates.push_back(1);
+        }
+    }
+
+    // First move (2 spaces forward)
+    if (checkWhitePlayer() && (x == 6) && !((*(this->getBoard()))[x - 2][y])) {
+        Box initialMove1(x - 2, y);
+        legalMoves.push_back(initialMove1);
+        moveStates.push_back(0);
+
+        // En passant (Note that we need to delete the newly added move to the opposing pawn 
+        // if it is not used immediately!)
+        if ((y - 1 >= 0) && ((*(this->getBoard()))[x - 2][y - 1])->getName() == "p") {
+            Box opponentPawnMove1(x - 1, y);
+            ((*(this->getBoard()))[x - 2][y - 1])->getLegalMoves()->push_back(opponentPawnMove1);
+            ((*(this->getBoard()))[x - 2][y - 1])->getMoveStates()->push_back(-1);
+        }
+
+        if ((y + 1 < 8) && ((*(this->getBoard()))[x - 2][y + 1])->getName() == "p") {
+            Box opponentPawnMove2(x - 1, y);
+            ((*(this->getBoard()))[x - 2][y + 1])->getLegalMoves()->push_back(opponentPawnMove2);
+            ((*(this->getBoard()))[x - 2][y + 1])->getMoveStates()->push_back(-1);
+        }
+    }
+
+    if (!checkWhitePlayer() && (x == 1) && !((*(this->getBoard()))[x - 2][y])) {
+        Box initialMove2(x + 2, y);
+        legalMoves.push_back(initialMove2);
+        moveStates.push_back(0);
+
+        // En passant (Note that we need to delete the newly added move to the opposing pawn 
+        // if it is not used immediately!)
+        if ((y - 1 >= 0) && ((*(this->getBoard()))[x + 2][y - 1])->getName() == "P") {
+            Box opponentPawnMove1(x + 1, y);
+            ((*(this->getBoard()))[x + 2][y - 1])->getLegalMoves()->push_back(opponentPawnMove1);
+            ((*(this->getBoard()))[x + 2][y - 1])->getMoveStates()->push_back(-1);
+        }
+
+        if ((y + 1 < 8) && ((*(this->getBoard()))[x + 2][y + 1])->getName() == "p") {
+            Box opponentPawnMove2(x + 1, y);
+            ((*(this->getBoard()))[x + 2][y + 1])->getLegalMoves()->push_back(opponentPawnMove2);
+            ((*(this->getBoard()))[x + 2][y + 1])->getMoveStates()->push_back(-1);
+        }
+    }
+
+    // Regular one space forward
+    if (checkWhitePlayer() && (x - 1 >= 0) && !((*(this->getBoard()))[x - 1][y])) {
+        Box move1(x - 1, y);
+        legalMoves.push_back(move1);
+        moveStates.push_back(0);
+    }
+
+    if (!checkWhitePlayer() && (x + 1 < 8) && !((*(this->getBoard()))[x - 1][y])) {
+        Box move2(x + 1, y);
+        legalMoves.push_back(move2);
+        moveStates.push_back(0);
+    }
+
+    this->getLegalMoves() = &legalMoves;
+    this->getMoveStates() = &moveStates;
+}

--- a/pawn.cc
+++ b/pawn.cc
@@ -1,4 +1,5 @@
 #include "pawn.h"
+#include <algorithm>
 
 Pawn::Pawn(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord):
     Piece{name, board,whitePlayer, xCoord, yCoord} {}
@@ -52,6 +53,22 @@ void Pawn::updateLegalMoves() {
             moveStates.push_back(1);
         }
     }
+
+    /* 
+        Check if there was an en passant (capture) move added by different pawn (not attacking pawn).
+        This is needed as we call updateLegalMoves() before every move attempted (check move() for more details).
+        Thus, in order to not loose the en passant move added by a different pawn we must push it again to new 
+        legalMoves array currently being constructed.
+    */
+
+    auto enPassant = std::find((this->getMoveStates())->begin(), (this->getMoveStates())->end(), -1);
+    if (enPassant != (this->getMoveStates())->end()) {
+        // en passant move (-1) was found in PREVIOUS legalMovesArr and legalMoveStates
+        int index = enPassant - (this->getMoveStates())->begin();
+        // add en passant move to CURRENT legalMovesArr - legalMoves - and CURRENT legalMoveStates - moveStates
+        legalMoves.push_back((*((this->getLegalMoves())->begin() + index)));
+        moveStates.push_back(-1);
+   }
 
     // First move (2 spaces forward)
     if (checkWhitePlayer() && (x == 6) && !((*(this->getBoard()))[x - 2][y])) {

--- a/pawn.h
+++ b/pawn.h
@@ -1,6 +1,14 @@
 #ifndef _PAWN_H_
 #define _PAWN_H_
 
+#include "piece.h"
 
+class Pawn: public Piece {
+    bool isLegal(Box &targetBox) override;
+
+    public:
+        Pawn(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
+        void updateLegalMoves() override;
+};
 
 #endif

--- a/pawn.h
+++ b/pawn.h
@@ -8,7 +8,7 @@ class Pawn: public Piece {
 
     public:
         Pawn(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
-        void updateLegalMoves() override;
+        std::map<Box, int> updateLegalMoves() override;
 };
 
 #endif

--- a/piece.h
+++ b/piece.h
@@ -2,6 +2,7 @@
 #define _PIECE_H_
 #include <string>
 #include <vector>
+#include <map>
 #include "box.h"
 
 class Piece {
@@ -11,8 +12,7 @@ class Piece {
     int xCoord;
     int yCoord;
 
-    std::vector<Box> * legalMovesArr;
-    std::vector<int> * legalMoveStates;
+    std::map<Box, int> *legalMovesArr;
 
     protected:
     virtual bool isLegal(Box &targetBox) = 0;
@@ -30,18 +30,18 @@ class Piece {
         int move(Piece *currentTile, Piece *targetTile, int newX, int newY);
         void print();
 
-        std::vector<Box> *& getLegalMoves() {
+        std::map<Box, int> *getLegalMoves() {
             return legalMovesArr;
         };
 
-        std::vector<int> *& getMoveStates() {
+        /*std::vector<int> *& getMoveStates() {
             return legalMoveStates;
-        };
+        };*/
 
         std::vector<std::vector<Piece *>> *& getBoard() {
             return board;
         };
-        virtual void updateLegalMoves() = 0;
+        virtual std::map<Box, int> updateLegalMoves() = 0;
         
         ~Piece();
 };

--- a/piece.h
+++ b/piece.h
@@ -12,7 +12,7 @@ class Piece {
     int xCoord;
     int yCoord;
 
-    std::map<Box, int> *legalMovesArr;
+    std::map<Box, int> *legalMovesMap;
 
     protected:
     virtual bool isLegal(Box &targetBox) = 0;
@@ -31,7 +31,7 @@ class Piece {
         void print();
 
         std::map<Box, int> *getLegalMoves() {
-            return legalMovesArr;
+            return legalMovesMap;
         };
 
         /*std::vector<int> *& getMoveStates() {

--- a/piece.h
+++ b/piece.h
@@ -12,24 +12,30 @@ class Piece {
     int yCoord;
 
     std::vector<Box> * legalMovesArr;
+    std::vector<int> * legalMoveStates;
 
     protected:
     virtual bool isLegal(Box &targetBox) = 0;
 
     public:
-        Piece(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, const int& xCoord, const int& yCoord);
+        Piece(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, const int xCoord, const int yCoord);
 
         int getX();
         int getY();
 
         std::string getName();
         bool checkWhitePlayer();
+        virtual bool getIsFirstMove() = 0;
         // if move is completed move will return 1
         int move(Piece *currentTile, Piece *targetTile, int newX, int newY);
         void print();
 
         std::vector<Box> *& getLegalMoves() {
             return legalMovesArr;
+        };
+
+        std::vector<int> *& getMoveStates() {
+            return legalMoveStates;
         };
 
         std::vector<std::vector<Piece *>> *& getBoard() {

--- a/queen.cc
+++ b/queen.cc
@@ -12,9 +12,8 @@ bool Queen::isLegal(Box &targetBox) {
     return false;
 }
 
-void Queen::updateLegalMoves() {
-    std::vector<Box> legalMoves;
-    std::vector<int> moveStates;
+std::map<Box, int> Queen::updateLegalMoves() {
+    std::map<Box, int> legalMoves;
 
     int x = this->getX();
     int y = this->getY();
@@ -30,14 +29,13 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
+
         // location is empty
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
     for (int i = x + 1; i < 8; ++i) {
@@ -45,13 +43,12 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        
+        legalMoves[move1] = 0;
     }
 
     for (int i = y + 1; i < 8; ++i) {
@@ -59,13 +56,12 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        
+        legalMoves[move1] = 0;
     }
 
     for (int i = y - 1; i >= 0; --i) {
@@ -73,13 +69,12 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        
+        legalMoves[move1] = 0;
     }
 
     // diagonal movements
@@ -89,13 +84,11 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x - i][y + i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
     for (int i = 1; x + i  < 8 && y - i >= 0; ++i) {
@@ -103,13 +96,11 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x + i][y - i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
     for (int i = 1; x - i  >= 0 && y - i >= 0; ++i) {
@@ -117,13 +108,11 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x - i][y - i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
     for (int i = 1; x + i  < 8 && y + i < 8; ++i) {
@@ -131,15 +120,12 @@ void Queen::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x + i][y + i])) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
-    this->getLegalMoves() = &legalMoves;
-    this->getMoveStates() = &moveStates;
+    return legalMoves;
 }

--- a/queen.cc
+++ b/queen.cc
@@ -4,7 +4,7 @@ Queen::Queen(std::string name, std::vector<std::vector<Piece *>> *board, bool wh
     Piece{name, board, whitePlayer, xCoord, yCoord} {}
 
 bool Queen::isLegal(Box &targetBox) {
-    // if location is EMPTY OR WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
+    // if WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
     if (((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
          (!checkWhitePlayer() && (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) )) {
         return true;
@@ -14,6 +14,7 @@ bool Queen::isLegal(Box &targetBox) {
 
 void Queen::updateLegalMoves() {
     std::vector<Box> legalMoves;
+    std::vector<int> moveStates;
 
     int x = this->getX();
     int y = this->getY();
@@ -25,102 +26,120 @@ void Queen::updateLegalMoves() {
     // horizontal and vertical movements
 
     for (int i = x - 1; i >= 0; --i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(i, y);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
+        // location is empty
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = x + 1; i < 8; ++i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(i, y);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = y + 1; i < 8; ++i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(x, i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = y - 1; i >= 0; --i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(x, i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     // diagonal movements
 
     for (int i = 1; x - i >= 0 && y + i < 8; ++i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(x - i, y + i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x - i][y + i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = 1; x + i  < 8 && y - i >= 0; ++i) {
-
         Box move1(x + i, y - i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x + i][y - i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = 1; x - i  >= 0 && y - i >= 0; ++i) {
-
         Box move1(x - i, y - i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x - i][y - i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = 1; x + i  < 8 && y + i < 8; ++i) {
-
         Box move1(x + i, y + i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if (((*(this->getBoard()))[x + i][y + i])) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     this->getLegalMoves() = &legalMoves;
+    this->getMoveStates() = &moveStates;
 }

--- a/queen.h
+++ b/queen.h
@@ -9,7 +9,7 @@ class Queen: public Piece {
 
     public:
         Queen(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
-        void updateLegalMoves() override;
+        std::map<Box, int> updateLegalMoves() override;
 };
 
 #endif

--- a/queen.h
+++ b/queen.h
@@ -5,7 +5,7 @@
 
 class Queen: public Piece {
     // isLegal() checks if move is capturable (opposite colour)
-    bool isLegal(Box targetBox) override;
+    bool isLegal(Box &targetBox) override;
 
     public:
         Queen(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);

--- a/rook.cc
+++ b/rook.cc
@@ -1,7 +1,7 @@
 #include "rook.h"
 
-Rook::Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord, bool isFirstMove):
-    Piece{name, board, whitePlayer, xCoord, yCoord}, isFirstMove{isFirstMove} {}
+Rook::Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord):
+    Piece{name, board, whitePlayer, xCoord, yCoord}, isFirstMove{true} {}
 
 bool Rook::getIsFirstMove() {
     return isFirstMove;

--- a/rook.cc
+++ b/rook.cc
@@ -16,9 +16,8 @@ bool Rook::isLegal(Box &targetBox) {
     return false;
 }
 
-void Rook::updateLegalMoves() {
-    std::vector<Box> legalMoves;
-    std::vector<int> moveStates;
+std::map<Box, int> Rook::updateLegalMoves() {
+    std::map<Box, int> legalMoves;
 
     int x = this->getX();
     int y = this->getY();
@@ -31,14 +30,13 @@ void Rook::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
+
         // location is empty
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        legalMoves[move1] = 0;
     }
 
     for (int i = x + 1; i < 8; ++i) {
@@ -46,13 +44,12 @@ void Rook::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+
+        legalMoves[move1] = 0;
     }
 
     for (int i = y + 1; i < 8; ++i) {
@@ -60,13 +57,12 @@ void Rook::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+        
+        legalMoves[move1] = 0;
     }
 
     for (int i = y - 1; i >= 0; --i) {
@@ -74,15 +70,13 @@ void Rook::updateLegalMoves() {
         // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
-                legalMoves.push_back(move1);
-                moveStates.push_back(1);
+                legalMoves[move1] = 1;
             }
             break;
         }
-        legalMoves.push_back(move1);
-        moveStates.push_back(0);
+
+        legalMoves[move1] = 0;
     }
 
-    this->getLegalMoves() = &legalMoves;
-    this->getMoveStates() = &moveStates;
+    return legalMoves;
 }

--- a/rook.cc
+++ b/rook.cc
@@ -1,10 +1,14 @@
 #include "rook.h"
 
-Rook::Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord):
-    Piece{name, board, whitePlayer, xCoord, yCoord} {}
+Rook::Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord, bool isFirstMove):
+    Piece{name, board, whitePlayer, xCoord, yCoord}, isFirstMove{isFirstMove} {}
+
+bool Rook::getIsFirstMove() {
+    return isFirstMove;
+}
 
 bool Rook::isLegal(Box &targetBox) {
-    // if location is EMPTY OR WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
+    // if WHITE CAPTURE BLACK OR BLACK CAPTURE WHITE
     if (((checkWhitePlayer() && !(((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) ||
          (!checkWhitePlayer() && (((*(this->getBoard()))[targetBox.getX()][targetBox.getY()])->checkWhitePlayer())) )) {
         return true;
@@ -14,6 +18,7 @@ bool Rook::isLegal(Box &targetBox) {
 
 void Rook::updateLegalMoves() {
     std::vector<Box> legalMoves;
+    std::vector<int> moveStates;
 
     int x = this->getX();
     int y = this->getY();
@@ -22,52 +27,62 @@ void Rook::updateLegalMoves() {
     // this is also why we need separate loops for each direction
 
     for (int i = x - 1; i >= 0; --i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(i, y);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
+        // location is empty
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = x + 1; i < 8; ++i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(i, y);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[i][y]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = y + 1; i < 8; ++i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(x, i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     for (int i = y - 1; i >= 0; --i) {
-        // if there exists a piece on box (break) and it is capturable add to possible moves
         Box move1(x, i);
+        // if there exists a piece on box (break) and it is capturable add to possible moves
         if ((*(this->getBoard()))[x][i]) {
             if(isLegal(move1)) {
                 legalMoves.push_back(move1);
+                moveStates.push_back(1);
             }
             break;
         }
         legalMoves.push_back(move1);
+        moveStates.push_back(0);
     }
 
     this->getLegalMoves() = &legalMoves;
+    this->getMoveStates() = &moveStates;
 }

--- a/rook.h
+++ b/rook.h
@@ -9,7 +9,8 @@ class Rook: public Piece {
     bool isLegal(Box &targetBox) override;
 
     public:
-        Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
+        Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord, bool isFirstMove);
+        bool getIsFirstMove() override;
         void updateLegalMoves() override;
 
 };

--- a/rook.h
+++ b/rook.h
@@ -9,7 +9,7 @@ class Rook: public Piece {
     bool isLegal(Box &targetBox) override;
 
     public:
-        Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord, bool isFirstMove);
+        Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
         bool getIsFirstMove() override;
         void updateLegalMoves() override;
 

--- a/rook.h
+++ b/rook.h
@@ -11,7 +11,7 @@ class Rook: public Piece {
     public:
         Rook(std::string name, std::vector<std::vector<Piece *>> *board, bool whitePlayer, int xCoord, int yCoord);
         bool getIsFirstMove() override;
-        void updateLegalMoves() override;
+        std::map<Box, int> updateLegalMoves() override;
 
 };
 


### PR DESCRIPTION
- Added `legalMoveStates` integer vector to Piece, Rook, Knight, Queen, and Bishop
- Implemented King and Pawn
- Added `legalMoveStates` integer vector for King and Pawn as well
- Can you guys pay close attention to `updateLegalMoves()` in King (especially checking if King is in check)

CHANGED LEGALMOVES AND MOVESTATES INTO A MAP!

Next steps for me:
- In `move()` make sure to check if pawn is at the end of board (if it is need to change it to a different Piece)
- Need to do something about **en passant** in `move()` (i.e. check if there is an en passant in `legalMoves` and if there is and it was not chosen (need to delete from `legalMoves`)
- Need to change first move after first move (I think this can be done in`move()`)
- In `move()` if king is making a castling move we need to move rook as well
